### PR TITLE
docs: real Example Usage in the registry index (VPC + CKS cluster)

### DIFF
--- a/docs/_index.md
+++ b/docs/_index.md
@@ -17,15 +17,274 @@ The CoreWeave provider is available as a package in all Pulumi languages:
 
 ## Example Usage
 
-```yaml
-# Pulumi.yaml provider configuration file
-name: configuration-example
-runtime:
-config:
-    coreweave:token:
-        value: CW-SECRET-XXXXXXXXXXXXX
+{{< chooser language "typescript,python,go,csharp,java,yaml" >}}
+{{% choosable language typescript %}}
+```typescript
+import * as pulumi from "@pulumi/pulumi";
+import * as coreweave from "@pulumi/coreweave";
+
+const _default = new coreweave.NetworkingVpc("default", {
+    name: "default",
+    zone: "US-EAST-04A",
+    vpcPrefixes: [
+        {
+            name: "pod cidr",
+            value: "10.0.0.0/13",
+        },
+        {
+            name: "service cidr",
+            value: "10.16.0.0/22",
+        },
+        {
+            name: "internal lb cidr",
+            value: "10.32.4.0/22",
+        },
+    ],
+});
+const defaultCksCluster = new coreweave.CksCluster("default", {
+    name: "default",
+    version: "v1.35",
+    zone: "US-EAST-04A",
+    vpcId: _default.id,
+    "public": true,
+    podCidrName: "pod cidr",
+    serviceCidrName: "service cidr",
+    internalLbCidrNames: ["internal lb cidr"],
+});
+```
+
+{{% /choosable %}}
+{{% choosable language python %}}
+```python
+import pulumi
+import pulumi_coreweave as coreweave
+
+default = coreweave.NetworkingVpc("default",
+    name="default",
+    zone="US-EAST-04A",
+    vpc_prefixes=[
+        {
+            "name": "pod cidr",
+            "value": "10.0.0.0/13",
+        },
+        {
+            "name": "service cidr",
+            "value": "10.16.0.0/22",
+        },
+        {
+            "name": "internal lb cidr",
+            "value": "10.32.4.0/22",
+        },
+    ])
+default_cks_cluster = coreweave.CksCluster("default",
+    name="default",
+    version="v1.35",
+    zone="US-EAST-04A",
+    vpc_id=default.id,
+    public=True,
+    pod_cidr_name="pod cidr",
+    service_cidr_name="service cidr",
+    internal_lb_cidr_names=["internal lb cidr"])
+```
+
+{{% /choosable %}}
+{{% choosable language csharp %}}
+```csharp
+using System.Collections.Generic;
+using System.Linq;
+using Pulumi;
+using CoreWeave = Pulumi.CoreWeave;
+
+return await Deployment.RunAsync(() =>
+{
+    var @default = new CoreWeave.NetworkingVpc("default", new()
+    {
+        Name = "default",
+        Zone = "US-EAST-04A",
+        VpcPrefixes = new[]
+        {
+            new CoreWeave.Inputs.NetworkingVpcVpcPrefixArgs
+            {
+                Name = "pod cidr",
+                Value = "10.0.0.0/13",
+            },
+            new CoreWeave.Inputs.NetworkingVpcVpcPrefixArgs
+            {
+                Name = "service cidr",
+                Value = "10.16.0.0/22",
+            },
+            new CoreWeave.Inputs.NetworkingVpcVpcPrefixArgs
+            {
+                Name = "internal lb cidr",
+                Value = "10.32.4.0/22",
+            },
+        },
+    });
+
+    var defaultCksCluster = new CoreWeave.CksCluster("default", new()
+    {
+        Name = "default",
+        Version = "v1.35",
+        Zone = "US-EAST-04A",
+        VpcId = @default.Id,
+        Public = true,
+        PodCidrName = "pod cidr",
+        ServiceCidrName = "service cidr",
+        InternalLbCidrNames = new[]
+        {
+            "internal lb cidr",
+        },
+    });
+
+});
 
 ```
+
+{{% /choosable %}}
+{{% choosable language go %}}
+```go
+package main
+
+import (
+	"github.com/pulumi/pulumi-coreweave/sdk/go/coreweave"
+	"github.com/pulumi/pulumi/sdk/v3/go/pulumi"
+)
+
+func main() {
+	pulumi.Run(func(ctx *pulumi.Context) error {
+		_default, err := coreweave.NewNetworkingVpc(ctx, "default", &coreweave.NetworkingVpcArgs{
+			Name: pulumi.String("default"),
+			Zone: pulumi.String("US-EAST-04A"),
+			VpcPrefixes: coreweave.NetworkingVpcVpcPrefixArray{
+				&coreweave.NetworkingVpcVpcPrefixArgs{
+					Name:  pulumi.String("pod cidr"),
+					Value: pulumi.String("10.0.0.0/13"),
+				},
+				&coreweave.NetworkingVpcVpcPrefixArgs{
+					Name:  pulumi.String("service cidr"),
+					Value: pulumi.String("10.16.0.0/22"),
+				},
+				&coreweave.NetworkingVpcVpcPrefixArgs{
+					Name:  pulumi.String("internal lb cidr"),
+					Value: pulumi.String("10.32.4.0/22"),
+				},
+			},
+		})
+		if err != nil {
+			return err
+		}
+		_, err = coreweave.NewCksCluster(ctx, "default", &coreweave.CksClusterArgs{
+			Name:            pulumi.String("default"),
+			Version:         pulumi.String("v1.35"),
+			Zone:            pulumi.String("US-EAST-04A"),
+			VpcId:           _default.ID(),
+			Public:          pulumi.Bool(true),
+			PodCidrName:     pulumi.String("pod cidr"),
+			ServiceCidrName: pulumi.String("service cidr"),
+			InternalLbCidrNames: pulumi.StringArray{
+				pulumi.String("internal lb cidr"),
+			},
+		})
+		if err != nil {
+			return err
+		}
+		return nil
+	})
+}
+```
+
+{{% /choosable %}}
+{{% choosable language yaml %}}
+```yaml
+resources:
+  default:
+    type: coreweave:NetworkingVpc
+    properties:
+      name: default
+      zone: US-EAST-04A
+      vpcPrefixes:
+        - name: pod cidr
+          value: 10.0.0.0/13
+        - name: service cidr
+          value: 10.16.0.0/22
+        - name: internal lb cidr
+          value: 10.32.4.0/22
+  defaultCksCluster:
+    type: coreweave:CksCluster
+    name: default
+    properties:
+      name: default
+      version: v1.35
+      zone: US-EAST-04A
+      vpcId: ${default.id}
+      public: true
+      podCidrName: pod cidr
+      serviceCidrName: service cidr
+      internalLbCidrNames:
+        - internal lb cidr
+```
+
+{{% /choosable %}}
+{{% choosable language java %}}
+```java
+package generated_program;
+
+import com.pulumi.Context;
+import com.pulumi.Pulumi;
+import com.pulumi.core.Output;
+import com.pulumi.coreweave.NetworkingVpc;
+import com.pulumi.coreweave.NetworkingVpcArgs;
+import com.pulumi.coreweave.inputs.NetworkingVpcVpcPrefixArgs;
+import com.pulumi.coreweave.CksCluster;
+import com.pulumi.coreweave.CksClusterArgs;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Map;
+import java.io.File;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+
+public class App {
+    public static void main(String[] args) {
+        Pulumi.run(App::stack);
+    }
+
+    public static void stack(Context ctx) {
+        var default_ = new NetworkingVpc("default", NetworkingVpcArgs.builder()
+            .name("default")
+            .zone("US-EAST-04A")
+            .vpcPrefixes(
+                NetworkingVpcVpcPrefixArgs.builder()
+                    .name("pod cidr")
+                    .value("10.0.0.0/13")
+                    .build(),
+                NetworkingVpcVpcPrefixArgs.builder()
+                    .name("service cidr")
+                    .value("10.16.0.0/22")
+                    .build(),
+                NetworkingVpcVpcPrefixArgs.builder()
+                    .name("internal lb cidr")
+                    .value("10.32.4.0/22")
+                    .build())
+            .build());
+
+        var defaultCksCluster = new CksCluster("defaultCksCluster", CksClusterArgs.builder()
+            .name("default")
+            .version("v1.35")
+            .zone("US-EAST-04A")
+            .vpcId(default_.id())
+            .public_(true)
+            .podCidrName("pod cidr")
+            .serviceCidrName("service cidr")
+            .internalLbCidrNames("internal lb cidr")
+            .build());
+
+    }
+}
+```
+
+{{% /choosable %}}
+{{< /chooser >}}
 ## Configuration Reference
 
 - `endpoint` (String) CoreWeave API Endpoint. This can also be set via the COREWEAVE_API_ENDPOINT environment variable, which takes precedence. Defaults to `https://api.coreweave.com/`

--- a/provider/resources.go
+++ b/provider/resources.go
@@ -15,6 +15,7 @@
 package coreweave
 
 import (
+	"bytes"
 	"path"
 
 	// Allow embedding bridge-metadata.json in the provider.
@@ -40,6 +41,35 @@ const (
 
 //go:embed cmd/pulumi-resource-coreweave/bridge-metadata.json
 var metadata []byte
+
+// The upstream Terraform provider's index doc only ships a
+// provider-configuration example, which the bridge renders as a trivial
+// Example Usage on the registry. providerConfigExample is that upstream
+// snippet; exampleUsageHCL is a real resource example (a VPC + a CKS
+// cluster) substituted in its place so the registry shows usable code.
+// The bridge converts this HCL to every SDK language.
+const providerConfigExample = "provider \"coreweave\" {\n  token = \"CW-SECRET-XXXXXXXXXXXXX\"\n}"
+
+const exampleUsageHCL = `resource "coreweave_networking_vpc" "default" {
+  name = "default"
+  zone = "US-EAST-04A"
+  vpc_prefixes = [
+    { name = "pod cidr", value = "10.0.0.0/13" },
+    { name = "service cidr", value = "10.16.0.0/22" },
+    { name = "internal lb cidr", value = "10.32.4.0/22" },
+  ]
+}
+
+resource "coreweave_cks_cluster" "default" {
+  name                   = "default"
+  version                = "v1.35"
+  zone                   = "US-EAST-04A"
+  vpc_id                 = coreweave_networking_vpc.default.id
+  public                 = true
+  pod_cidr_name          = "pod cidr"
+  service_cidr_name      = "service cidr"
+  internal_lb_cidr_names = ["internal lb cidr"]
+}`
 
 // Provider returns additional overlaid schema and metadata associated with the provider.
 func Provider() tfbridge.ProviderInfo {
@@ -82,6 +112,18 @@ func Provider() tfbridge.ProviderInfo {
 		// (which cannot resolve the filesystem-replaced submodule).
 		UpstreamRepoPath: "./upstream",
 		MetadataInfo:     tfbridge.NewProviderMetadata(metadata),
+		DocRules: &tfbridge.DocRuleInfo{
+			EditRules: func(defaults []tfbridge.DocsEdit) []tfbridge.DocsEdit {
+				return append(defaults, tfbridge.DocsEdit{
+					Path: "index.md",
+					Edit: func(_ string, content []byte) ([]byte, error) {
+						return bytes.Replace(content,
+							[]byte(providerConfigExample),
+							[]byte(exampleUsageHCL), 1), nil
+					},
+				})
+			},
+		},
 		JavaScript: &tfbridge.JavaScriptInfo{
 			// RespectSchemaVersion ensures the SDK is generated linking to the correct version of the provider.
 			RespectSchemaVersion: true,


### PR DESCRIPTION
## Summary

The registry docset's `## Example Usage` was a trivial provider-config stub (`name: configuration-example`) because the upstream Terraform provider's `docs/index.md` only ships a `provider "coreweave" {}` snippet, and the bridge converts whatever HCL is in that index doc.

Add a `DocRules.EditRules` rule that replaces the upstream provider-config snippet with a real resource example (a `coreweave_networking_vpc` + `coreweave_cks_cluster`, mirroring `examples/basic`). The bridge `pulumi convert`s it, so `docs/_index.md` now renders a proper multi-language `{{< chooser >}}` (TypeScript/Python/Go/C#/Java/YAML), like `pulumi-cloudflare` and other first-party providers.

## Scope

- `provider/resources.go` — `DocRules.EditRules` + the HCL example consts (+`bytes` import)
- `docs/_index.md` — regenerated; Example Usage is now the converted chooser

`make generate` produces no other changes — schemas and SDKs are unaffected (an index example is not a resource example).

Once released, the registry picks this up via the first-party re-fetch (pulumi/registry#11036).

Part of pulumi/home#4701
Refs pulumi/registry#11036

🤖 Generated with [Claude Code](https://claude.com/claude-code)