### PR TITLE
examples/basic: construct kubeconfig

### DIFF
--- a/examples/basic/.gitignore
+++ b/examples/basic/.gitignore
@@ -1,5 +1,3 @@
 /bin/
 /node_modules/
-kubeconfig.yaml
-kubeconfig.yml
 Pulumi.dev.yaml

--- a/examples/basic/README.md
+++ b/examples/basic/README.md
@@ -8,12 +8,10 @@ This is an example program that demonstrates how to use the CoreWeave provider w
   - Node.js installed
 
 ### Description
-The Pulumi program here works in two phases. The first phase sets up the networking VPC and the cluster within that VPC.
-
-Once the cluster is deployed. The second phase starts where we will need to download the `kubeconfig` of the cluster for the second phase in order to be able to connect to the cluster and deploy node pools within it. 
+The program provisions a networking VPC, a CKS cluster within that VPC, and a CPU node pool on the cluster in a single deployment. The kubeconfig used to talk to the cluster is assembled in-program from the cluster's `apiServerEndpoint` output and the same CoreWeave token used to authenticate the provider, so no manual kubeconfig download is required.
 
 ### Setting up credentials
-Make you are have a CoreWeave API token which you can get from the CoreWeave console. You can set this as a configuration for your Pulumi program as follows.
+Make sure you have a CoreWeave API token, which you can get from the CoreWeave console. You can set this as a configuration value for your Pulumi program as follows.
 
 First initialize a new Pulumi stack:
 ```
@@ -24,34 +22,32 @@ Then add the token to your config:
 pulumi config set coreweave:token <your_api_token> --secret
 ```
 
+The program reads `coreweave:token` to authenticate both the CoreWeave provider and the Kubernetes provider it builds for the cluster.
 
-### Phase 1: deploying the cluster
+### Deploying
 
 Make sure the package dependencies are installed:
 ```
 pulumi install
 ```
-This will install the required program dependencies as well as any required Pulumi plugins such the provider plugin for CoreWeave and the kubernetes provider.
+This will install the required program dependencies as well as the provider plugins for CoreWeave and Kubernetes.
 
-Run preview to see what resources will be created
+Run preview to see what resources will be created:
 ```bash
 pulumi preview
 ```
 You should see something like this:
 ```
-     Type                              Name         Plan       
- +   pulumi:pulumi:Stack               <stack-name>        create     
- +   ├─ pulumi:providers:coreweave     coreweave    create     
- +   ├─ coreweave:index:NetworkingVpc  cluster-vpc  create     
- +   └─ coreweave:index:CksCluster     my-cluster   create     
-
-Outputs:
-    clusterId  : [unknown]
-    clusterName: "my-cluster-0607e23"
-    vpcId      : [unknown]
+     Type                                                   Name          Plan
+ +   pulumi:pulumi:Stack                                    <stack-name>  create
+ +   ├─ pulumi:providers:coreweave                          coreweave     create
+ +   ├─ coreweave:index:NetworkingVpc                       cluster-vpc   create
+ +   ├─ coreweave:index:CksCluster                          my-cluster    create
+ +   ├─ pulumi:providers:kubernetes                         k8s-provider  create
+ +   └─ kubernetes:compute.coreweave.com/v1alpha1:NodePool  nodepool      create
 
 Resources:
-    + 4 to create
+    + 6 to create
 ```
 If everything looks good, you can proceed to deploy the resources:
 ```bash
@@ -59,36 +55,8 @@ pulumi up
 ```
 This will prompt you to confirm the deployment. Type `yes` to proceed. Once the deployment is complete, you will see the outputs which include the `clusterId`, `clusterName`, and `vpcId`.
 
-### Phase 2: deploying node pools
-
-Before being able to deploy node pools, you will need to download the `kubeconfig` for the cluster that was created in phase 1 from the console and add it as a file in this directory called `kubeconfig.yaml`. This file name is git-ignored and should not be committed to version control.
-
-Next time you run the program, it will detect the `kubeconfig.yaml` file and will use it to connect to the cluster and deploy the node pools within it.
-
-The program will create a CPU Node Pool with one node. Make sure your account has quota for the instance type that is being used in the node pool. You can change the instance type in the `index.ts` file if needed.
-
-Run the preview again to see the changes that will be made:
-```bash
-pulumi preview
-```
-You should see something like this:
-```
-     Type                                                   Name          Plan       
-     pulumi:pulumi:Stack                                    <stack-name>           update         
- +   ├─ pulumi:providers:kubernetes                         k8s-provider  create     
- +   └─ kubernetes:compute.coreweave.com/v1alpha1:NodePool  nodepool      create     
-
-Resources:
-    + 2 to create
-```
-If everything looks good, you can proceed to deploy the resources:
-```bash
-pulumi up
-```
-This will prompt you to confirm the deployment. Type `yes` to proceed. Once the deployment.
-
-This will now deploy the node pool to the cluster with a single node in it. Note that the node won't be available right away, instead it will be queued for provisioning and will be available after a while. You can check the status of the node pool in the CoreWeave console. Once the node is available, you can use it to run your workloads on the cluster.
+The program will create a CPU node pool with one node. Make sure your account has quota for the instance type that is being used. You can change the instance type in `index.ts`. Note that the node won't be available right away; it will be queued for provisioning and become available after a while. You can check the status in the CoreWeave console.
 
 ### Teardown
 
-Simply run `pulumi destroy` to tear down all the resources that were created by this program. It is better to delete the cluster only after the node pools have been actually been provisioned.
+Run `pulumi destroy` to tear down all the resources created by this program. It is better to delete the cluster only after the node pools have actually been provisioned.

--- a/examples/basic/apiServer.ts
+++ b/examples/basic/apiServer.ts
@@ -1,0 +1,26 @@
+import * as pulumi from "@pulumi/pulumi";
+
+// waitForApiServer polls the cluster's API server until its schema is available.
+export async function waitForApiServer(endpoint: string, token: string, deadline: number): Promise<void> {
+    const url = `https://${endpoint}/openapi/v2`;
+    pulumi.log.info(`waiting for api-server at ${url} to return 200`);
+
+    let lastError: string | undefined;
+    while (Date.now() < deadline) {
+        try {
+            const res = await fetch(url, {
+                headers: { Authorization: `Bearer ${token}` },
+                signal: AbortSignal.timeout(10000),
+            });
+            await res.body?.cancel();
+            if (res.status === 200) {
+                return;
+            }
+            lastError = `HTTP ${res.status}`;
+        } catch (err) {
+            lastError = err instanceof Error ? err.message : String(err);
+        }
+        await new Promise((r) => setTimeout(r, 5000));
+    }
+    throw new Error(`api server at ${endpoint} did not become ready: ${lastError}`);
+}

--- a/examples/basic/index.ts
+++ b/examples/basic/index.ts
@@ -1,9 +1,8 @@
 import * as pulumi from "@pulumi/pulumi";
 import * as coreweave from "@pulumi/coreweave";
 import * as k8s from "@pulumi/kubernetes";
-import { existsSync, readFileSync } from "fs";
 import * as cpuTypes from "./cpuTypes";
-
+import { waitForApiServer } from "./apiServer";
 
 const config = new pulumi.Config();
 // network configuration with defaults
@@ -12,12 +11,16 @@ const podCidr = config.get("podCidr") || "10.0.0.0/13";
 const serviceCidr = config.get("serviceCidr") || "10.16.0.0/22";
 const zone = config.get("zone") || "US-WEST-04A";
 
-// phase 1: create the kubernetes cluster and its vpc with defaults
+// the same token used to authenticate the coreweave provider, reused below
+// to authenticate to the cluster's api-server.
+const token = new pulumi.Config("coreweave").requireSecret("token");
+
+// create the kubernetes cluster and its vpc with defaults
 const defaultVpc = new coreweave.NetworkingVpc("cluster-vpc", {
     zone: zone,
     vpcPrefixes: [
         { name: "internal-lb-cidr", value: internalLbCidr },
-        { name: "pod-cidr",  value: podCidr },
+        { name: "pod-cidr", value: podCidr },
         { name: "service-cidr", value: serviceCidr }
     ]
 });
@@ -36,29 +39,50 @@ export const clusterId = cluster.id;
 export const clusterName = cluster.name;
 export const vpcId = defaultVpc.id;
 
-if (existsSync("kubeconfig.yaml")) {
-    // phase 2: connect to the kubernetes cluster and deploy node pools
-    // acquire the kubeconfig from the console and 
-    // save it as kubeconfig.yaml in this directory
-    const kubeconfig = readFileSync("kubeconfig.yaml", "utf-8");
-    const k8sProvider = new k8s.Provider("k8s-provider", {
-        kubeconfig: pulumi.secret(kubeconfig),
-    });
+// Gate the kubeconfig on api-server readiness so the k8s provider does not race ahead of DNS propagation or api-server startup.
+const apiServerEndpoint = pulumi.all([cluster.apiServerEndpoint, token]).apply(async ([endpoint, tok]) => {
+    if (pulumi.runtime.isDryRun()) {
+        return endpoint;
+    }
+    await waitForApiServer(endpoint, tok, Date.now() + 10 * 60 * 1000);
+    return endpoint;
+});
 
-    const nodePool = new k8s.apiextensions.CustomResource("nodepool", {
-        apiVersion: "compute.coreweave.com/v1alpha1",
-        kind: "NodePool",
-        metadata: {
-            name: "my-pulumi-nodepool",
-        },
-        spec: {
-            autoscaling: false,
-            instanceType: cpuTypes.GeneralPurpose_Intel_EmeraldRapid,
-            targetNodes: 1,
-            nodeConfigurationUpdateStrategy: { type: "OnSpecUpdate" },
-        },
-    }, { 
-        provider: k8sProvider,
-        dependsOn: [cluster],
-    });
-}
+const kubeconfig = pulumi.interpolate`apiVersion: v1
+kind: Config
+preferences: {}
+clusters:
+- name: ${cluster.name}
+  cluster:
+    server: https://${apiServerEndpoint}
+contexts:
+- name: ${cluster.name}
+  context:
+    cluster: ${cluster.name}
+    user: coreweave
+current-context: ${cluster.name}
+users:
+- name: coreweave
+  user:
+    token: ${token}
+`;
+
+const k8sProvider = new k8s.Provider("k8s-provider", {
+    kubeconfig: kubeconfig,
+});
+
+const nodePool = new k8s.apiextensions.CustomResource("nodepool", {
+    apiVersion: "compute.coreweave.com/v1alpha1",
+    kind: "NodePool",
+    metadata: {
+        name: "my-pulumi-nodepool",
+    },
+    spec: {
+        autoscaling: false,
+        instanceType: cpuTypes.GeneralPurpose_Intel_EmeraldRapid,
+        targetNodes: 1,
+        nodeConfigurationUpdateStrategy: { type: "OnSpecUpdate" },
+    },
+}, {
+    provider: k8sProvider,
+});


### PR DESCRIPTION
These changes construct a kubeconfig for the CKS cluster inline so that
the cluster and its node pool can be deployed in the same `pulumi up`.
The program will wait for up to 10 minutes for the cluster to become
available.
